### PR TITLE
Mise en garde contre un branchement d'un capteur au 5V du GPIO

### DIFF
--- a/StationMeteo/introBME280.ipynb
+++ b/StationMeteo/introBME280.ipynb
@@ -9,11 +9,12 @@
     "Activité réalisée avec un capteur Adafruit BME280, une raspberry Pi3 fonctionnant avec une image Debian Stretch fournie par l'IFÉ ENS de Lyon, disposant des librairies INTEL mraa et upm.\n",
     "\n",
     "Sur le site de Adafruit https://learn.adafruit.com/adafruit-bme280-humidity-barometric-pressure-temperature-sensor-breakout/pinouts on lit que 4 broches doivent être connectées au raspberryPi lorsqu'on travaille avec le bus I2C\n",
-    "* Vin - C'est la broche d'alimentation : elle peut-être relié à 3,3V ou 5V (Nous le relierons au 3,3V dans cet exercice)\n",
+    "* Vin - C'est la broche d'alimentation : elle peut-être relié à 3,3V ou 5V (Nous le relierons au 3,3V dans cet exercice). \n",
     "* GND - broche à relier à une broche ground du RasberryPi\n",
-    " et\n",
-    "* SCK - c'est la broche d'horloge du bus I2C\n",
-    "* SDI - c'est la broche de données du bus I2C\n",
+    "* SCK - c'est la broche d'horloge du bus I2C à relier à la broche 5 (SCL)\n",
+    "* SDI - c'est la broche de données du bus I2C à relier à la broche 3 (SDA)\n",
+    "\n",
+    "<span style='color:red'>ATTENTION : il ne faut pas brancher la broche Vin du capteur directement au 5V du RaspberryPi car le transfert des données se ferait aussi en 5V ce qui endommagerait le GPIO. </span> Nous verrons dans un autre exercice qu'il faut utiliser, pour les capteurs necessitant du 5V et ne fonctionnant pas en 3.3V, un [levelshifter (convertisseur de tension)](https://www.adafruit.com/product/757)\n",
     "\n",
     "![Capteur BME280 branché sur le bus I2C d'un RaspberryPi](images/RaspberryPi_BME280L.jpg)\n",
     "\n",
@@ -34,14 +35,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "32.51 °C\n"
+      "24.05 °C\n"
      ]
     }
    ],


### PR DESCRIPTION
et utilisation d'un level shifter si le capteur nécessite du 5V
	modifié :         StationMeteo/introBME280.ipynb